### PR TITLE
Feature: add checkbox for clear_border and spinboxes for flow_threshold and cellprob_threshold

### DIFF
--- a/src/napari_serialcellpose/serial_analysis.py
+++ b/src/napari_serialcellpose/serial_analysis.py
@@ -5,7 +5,7 @@ from skimage.measure import regionprops_table
 import pandas as pd
 
 def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
-                 diameter=None, clear_border=True):
+                 diameter=None, flow_threshold=0.4, cellprob_threshold=0.0, clear_border=True):
     """Run cellpose on image.
     
     Parameters
@@ -44,7 +44,7 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
     output_path = Path(output_path)
     
     # run cellpose
-    cellpose_output = cellpose_model.eval(image, channels = [[0,0]], diameter=diameter)
+    cellpose_output = cellpose_model.eval(image, channels = [[0,0]], diameter=diameter, flow_threshold=flow_threshold, cellprob_threshold=cellprob_threshold)
     cellpose_output = cellpose_output[0]
 
     if clear_border is True:

--- a/src/napari_serialcellpose/serial_analysis.py
+++ b/src/napari_serialcellpose/serial_analysis.py
@@ -19,6 +19,10 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
         scaling factor for image (not implemented)
     diameter : int
         diameter of cells to segment, only useful for native cellpose models
+    flow_threshold : float
+        cellpose setting: maximum allowed error of the flows for each mask
+    cellprob_threshold : float
+        cellpose setting: pixels greater than the cellprob_threshold are used to run dynamics and determine ROIs
     clear_border : bool
         remove cells touching border
 

--- a/src/napari_serialcellpose/serial_widget.py
+++ b/src/napari_serialcellpose/serial_widget.py
@@ -99,10 +99,11 @@ class SerialWidget(QWidget):
         self.spinbox_batch_size.setValue(3)
         self.options_group.glayout.addWidget(self.spinbox_batch_size, 0, 1, 1, 1)
 
-        self.options_group.glayout.addWidget(QLabel("Rescaling factor"), 1, 0, 1, 1)
-        self.spinbox_rescaling = QSpinBox()
-        self.spinbox_rescaling.setValue(1)
-        self.options_group.glayout.addWidget(self.spinbox_rescaling, 1, 1, 1, 1)
+        # Not yet implemented
+        # self.options_group.glayout.addWidget(QLabel("Rescaling factor"), 1, 0, 1, 1)
+        # self.spinbox_rescaling = QSpinBox()
+        # self.spinbox_rescaling.setValue(1)
+        # self.options_group.glayout.addWidget(self.spinbox_rescaling, 1, 1, 1, 1)
 
         self.diameter_label = QLabel("Diameter", visible=False)
         self.options_group.glayout.addWidget(self.diameter_label, 2, 0, 1, 1)

--- a/src/napari_serialcellpose/serial_widget.py
+++ b/src/napari_serialcellpose/serial_widget.py
@@ -111,6 +111,10 @@ class SerialWidget(QWidget):
         self.spinbox_diameter.setMaximum(1000)
         self.options_group.glayout.addWidget(self.spinbox_diameter, 2, 1, 1, 1)
 
+        self.check_clear_border = QCheckBox('Clear labels on border')
+        self.check_clear_border.setChecked(True)
+        self.options_group.glayout.addWidget(self.check_clear_border)
+
         self.plot_group = VHGroup('Plots')
         self._properties_layout.addWidget(self.plot_group.gbox)
 
@@ -209,7 +213,8 @@ class SerialWidget(QWidget):
             cellpose_model=self.cellpose_model,
             output_path=self.output_folder,
             scaling_factor=self.spinbox_rescaling.value(),
-            diameter=diameter
+            diameter=diameter,
+            clear_border=self.check_clear_border.isChecked()
         )
         self.viewer.add_labels(segmented, name='mask')
         props = load_props(self.output_folder, image_path)
@@ -236,7 +241,8 @@ class SerialWidget(QWidget):
                 cellpose_model=self.cellpose_model,
                 output_path=self.output_folder,
                 scaling_factor=self.spinbox_rescaling.value(),
-                diameter=diameter
+                diameter=diameter,
+                clear_border=self.check_clear_border.isChecked()
             )
 
     def output_and_model_check(self):

--- a/src/napari_serialcellpose/serial_widget.py
+++ b/src/napari_serialcellpose/serial_widget.py
@@ -227,7 +227,7 @@ class SerialWidget(QWidget):
             image_path=image_path,
             cellpose_model=self.cellpose_model,
             output_path=self.output_folder,
-            scaling_factor=self.spinbox_rescaling.value(),
+            # scaling_factor=self.spinbox_rescaling.value(), # not implemented yet
             diameter=diameter,
             flow_threshold=self.flow_threshold.value(),
             cellprob_threshold=self.cellprob_threshold.value(),
@@ -257,7 +257,7 @@ class SerialWidget(QWidget):
                 image_path=batch,
                 cellpose_model=self.cellpose_model,
                 output_path=self.output_folder,
-                scaling_factor=self.spinbox_rescaling.value(),
+                # scaling_factor=self.spinbox_rescaling.value(), # not implemented yet
                 diameter=diameter,
                 flow_threshold=self.flow_threshold.value(),
                 cellprob_threshold=self.cellprob_threshold.value(),

--- a/src/napari_serialcellpose/serial_widget.py
+++ b/src/napari_serialcellpose/serial_widget.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import (QWidget, QVBoxLayout,QFileDialog, QPushButton,
-QSpinBox, QLabel, QGridLayout, QHBoxLayout, QGroupBox, QComboBox, QTabWidget,
+QSpinBox, QDoubleSpinBox, QLabel, QGridLayout, QHBoxLayout, QGroupBox, QComboBox, QTabWidget,
 QCheckBox, QSlider)
 from qtpy.QtCore import Qt
 import magicgui.widgets
@@ -111,9 +111,23 @@ class SerialWidget(QWidget):
         self.spinbox_diameter.setMaximum(1000)
         self.options_group.glayout.addWidget(self.spinbox_diameter, 2, 1, 1, 1)
 
+        self.flow_threshold_label = QLabel("Flow threshold")
+        self.options_group.glayout.addWidget(self.flow_threshold_label, 3, 0, 1, 1)
+        self.flow_threshold = QDoubleSpinBox()
+        self.flow_threshold.setSingleStep(0.1)
+        self.flow_threshold.setValue(0.4)
+        self.options_group.glayout.addWidget(self.flow_threshold, 3, 1, 1, 1)
+
+        self.cellprob_threshold_label = QLabel("Cell probability threshold")
+        self.options_group.glayout.addWidget(self.cellprob_threshold_label, 4, 0, 1, 1)
+        self.cellprob_threshold = QDoubleSpinBox()
+        self.cellprob_threshold.setSingleStep(0.1)
+        self.cellprob_threshold.setValue(0.0)
+        self.options_group.glayout.addWidget(self.cellprob_threshold, 4, 1, 1, 1)
+
         self.check_clear_border = QCheckBox('Clear labels on border')
         self.check_clear_border.setChecked(True)
-        self.options_group.glayout.addWidget(self.check_clear_border)
+        self.options_group.glayout.addWidget(self.check_clear_border)   
 
         self.plot_group = VHGroup('Plots')
         self._properties_layout.addWidget(self.plot_group.gbox)
@@ -214,6 +228,8 @@ class SerialWidget(QWidget):
             output_path=self.output_folder,
             scaling_factor=self.spinbox_rescaling.value(),
             diameter=diameter,
+            flow_threshold=self.flow_threshold.value(),
+            cellprob_threshold=self.cellprob_threshold.value(),
             clear_border=self.check_clear_border.isChecked()
         )
         self.viewer.add_labels(segmented, name='mask')
@@ -242,6 +258,8 @@ class SerialWidget(QWidget):
                 output_path=self.output_folder,
                 scaling_factor=self.spinbox_rescaling.value(),
                 diameter=diameter,
+                flow_threshold=self.flow_threshold.value(),
+                cellprob_threshold=self.cellprob_threshold.value(),
                 clear_border=self.check_clear_border.isChecked()
             )
 


### PR DESCRIPTION
This PR is related to: https://forum.image.sc/t/differences-in-cellpose-napari-and-napari-serialcellpose-serial-widget/69227
I had some time and, because I use this plugin, I wanted to contribute a bit.
I added a checkbox for `clear_borders`.
I've never done anything with these types of widgets, so it was a learning thing, but at least locally it works for me on some test images.

Edit: I've added `flow_threshold` and `cellprob_threshold`. I added them to this PR, rather than a new one, to make it easier for the original poster to test.