### PR TITLE
Quick use

### DIFF
--- a/src/napari_serialcellpose/folder_list_widget.py
+++ b/src/napari_serialcellpose/folder_list_widget.py
@@ -37,7 +37,9 @@ class FolderList(QListWidget):
             for url in event.mimeData().urls():
                 file = str(url.toLocalFile())
                 if not Path(file).is_dir():
-                    raise NotImplementedError("You need to drag and drop a folder")
+                    self.update_from_path(Path(file).parent)
+                    file_list = [self.item(x).text() for x in range(self.count())]
+                    self.setCurrentRow(file_list.index(Path(file).name))
                 else:
                     self.update_from_path(Path(file))
 

--- a/src/napari_serialcellpose/serial_analysis.py
+++ b/src/napari_serialcellpose/serial_analysis.py
@@ -44,8 +44,6 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
             image[i] = image_gray
         if scaling_factor != 1:
             image[i] = image[i][::scaling_factor, ::scaling_factor]
-
-    output_path = Path(output_path)
     
     # run cellpose
     cellpose_output = cellpose_model.eval(image, channels = [[0,0]], diameter=diameter, flow_threshold=flow_threshold, cellprob_threshold=cellprob_threshold)
@@ -58,14 +56,16 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
     
     # save output
     for im, p in zip(cellpose_output, image_path):
-        save_path = output_path.joinpath(p.stem+'_mask.tif')
-        skimage.io.imsave(save_path, im, check_contrast=False)
+        if output_path is not None:
+            output_path = Path(output_path)
+            save_path = output_path.joinpath(p.stem+'_mask.tif')
+            skimage.io.imsave(save_path, im, check_contrast=False)
 
-        compute_props(
-            label_image=im,
-            output_path=output_path,
-            image_name=p
-            )
+            compute_props(
+                label_image=im,
+                output_path=output_path,
+                image_name=p
+                )
 
     return cellpose_output
 


### PR DESCRIPTION
This PR add a two functionalities to make it easier to use the plugin just to quickly check the quality of a model: 

- one can now just drag and drop a single image in the file list widget. This automatically updates the folder to the location of that image and also directly displays the image.
- a single image opened in the viewer (as implemented by the above feature) can now be analyzed without setting an output folder. Of course in that case the segmentation is not saved.

These changes allow for example to just drag and drop a file, pick a model, and click "Run on current image" to see the result.