### PR TITLE
enable multiscene analysis

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ testing =
     napari
     pyqt5
     cellpose < 4
+    bioio-nd2
 
 
 [options.packages.find]

--- a/src/napari_serialcellpose/serial_analysis.py
+++ b/src/napari_serialcellpose/serial_analysis.py
@@ -73,15 +73,19 @@ def run_cellpose(image_path, scene, cellpose_model, output_path, scaling_factor=
     if scene is not None and not isinstance(scene, list):
         scene = [scene]
 
+    scene_iterator = scene
+    if scene is None:
+        scene_iterator = [None]*len(image_path)
+
     if properties is None:
         properties = []
 
     channels = [0, 0]
     #bioimage = [BioImage(x) for x in image_path]
     bioimage = []
-    for impath, sc in zip(image_path, scene):
+    for impath, sc in zip(image_path, scene_iterator):
         bim = BioImage(impath)
-        if scene is not None:
+        if sc is not None:
             bim.set_scene(sc)
         bioimage.append(bim)
     img = bioimage[0]
@@ -182,9 +186,6 @@ def run_cellpose(image_path, scene, cellpose_model, output_path, scaling_factor=
         cellpose_output = [skimage.segmentation.relabel_sequential(im)[0] for im in cellpose_output]
     
     # save output
-    scene_iterator = scene
-    if scene is None:
-        scene_iterator = [None]*len(image_path)
     for im, im_m, p, s in zip(cellpose_output, image_measure, image_path, scene_iterator):
         props=None
         if len(properties) > 0:

--- a/src/napari_serialcellpose/serial_analysis.py
+++ b/src/napari_serialcellpose/serial_analysis.py
@@ -1,3 +1,4 @@
+from os import name
 from pathlib import Path
 import warnings
 import skimage.io
@@ -11,7 +12,7 @@ import yaml
 from .utils import get_cp_version
 __cp_version__ = get_cp_version()
 
-def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
+def run_cellpose(image_path, scene, cellpose_model, output_path, scaling_factor=1,
                  diameter=None, flow_threshold=0.4, cellprob_threshold=0.0,
                  clear_border=True, channel_to_segment=0, channel_helper=0,
                  channel_measure=None, channel_measure_names=None, properties=None,
@@ -20,8 +21,10 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
     
     Parameters
     ----------
-    image_path : str or Path
+    image_path : str or Path or list of str or Path
         path to image
+    scene : int, or list of ints, default None
+        index of scene(s) to process
     cellpose_model : cellpose model instance
     output_path : str or Path
         path to output folder
@@ -37,10 +40,13 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
         remove cells touching border
     channel_to_segment : int, default 0
         index of channel to segment, if image is multi-channel
+        for historical reasons, channel index is 1-indexed; 0 means single-channel image
     channel_helper : int, default 0
         index of helper nucleus channel for models using both cell and nucleus channels
+        for historical reasons, channel index is 1-indexed; 0 means single-channel image
     channel_measure: int or list of int, default None
         index of channel(s) in which to measure intensity
+        this channel is different from the segmentation and helper channels and is 0-indexed
     channel_measure_names: list of str, default None
         names of channel(s) in which to measure intensity
     properties = list of str, default None
@@ -58,14 +64,26 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
         properties of segmented cells for the last analyzed image
     """
 
+    if isinstance(image_path, list) and isinstance(scene, list):
+        if len(image_path) != len(scene):
+            raise ValueError('if image_path and scene are both lists, they must have the same length')
     if not isinstance(image_path, list):
         image_path = [image_path]
+
+    if scene is not None and not isinstance(scene, list):
+        scene = [scene]
 
     if properties is None:
         properties = []
 
     channels = [0, 0]
-    bioimage = [BioImage(x) for x in image_path]
+    #bioimage = [BioImage(x) for x in image_path]
+    bioimage = []
+    for impath, sc in zip(image_path, scene):
+        bim = BioImage(impath)
+        if scene is not None:
+            bim.set_scene(sc)
+        bioimage.append(bim)
     img = bioimage[0]
     image_measure = [None]*len(image_path)
 
@@ -164,7 +182,10 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
         cellpose_output = [skimage.segmentation.relabel_sequential(im)[0] for im in cellpose_output]
     
     # save output
-    for im, im_m, p in zip(cellpose_output, image_measure, image_path):
+    scene_iterator = scene
+    if scene is None:
+        scene_iterator = [None]*len(image_path)
+    for im, im_m, p, s in zip(cellpose_output, image_measure, image_path, scene_iterator):
         props=None
         if len(properties) > 0:
             props = compute_props(
@@ -172,13 +193,15 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
                     intensity_image=im_m,
                     output_path=output_path,
                     image_name=p,
+                    scene=s,
                     properties=properties,
                     channel_names=channel_measure_names
                     )
 
         if output_path is not None:
             output_path = Path(output_path)
-            save_path = output_path.joinpath(p.stem+'_mask.tif')
+            scene_suffix = '' if scene is None else f'_scene{s}'
+            save_path = output_path.joinpath(p.stem + scene_suffix + '_mask.tif')
             skimage.io.imsave(save_path, im, check_contrast=False)
 
     return cellpose_output, props
@@ -186,7 +209,7 @@ def run_cellpose(image_path, cellpose_model, output_path, scaling_factor=1,
 
 def compute_props(
     label_image, intensity_image, output_path=None,
-    image_name=None, properties=None, channel_names=None):
+    image_name=None, scene=None, properties=None, channel_names=None):
     """Compute properties of segmented image.
     
     Parameters
@@ -199,6 +222,8 @@ def compute_props(
         path to output folder
     image_name : str or Path
         either path to image or image name
+    scene : int, default None
+        index of scene
     properties = list of str, default None
         list of types of properties to compute. Any of 'intensity', 'perimeter', 'shape', 'position', 'moments'
     channel_names: list of str, default None
@@ -230,7 +255,9 @@ def compute_props(
                         columns={f'{x}-{ind}': f'{x}-{c}'}, inplace=True)
 
     if output_path is not None:
-        props.to_csv(output_path.joinpath(image_name.stem+'_props.csv'), index=False)
+        scene_suffix = '' if scene is None else f'_scene{scene}'
+        name = output_path.joinpath(image_name.stem + scene_suffix + '_props.csv')
+        props.to_csv(name, index=False)
 
     return props
 
@@ -294,4 +321,23 @@ def load_allprops(output_path):
     all_props.to_csv(output_path.joinpath('summary.csv'), index=False)
 
     return all_props
+
+def get_scenes(image_path):
+    """Get number of scenes in a bioimage file.
+    
+    Parameters
+    ----------
+    image_path : str or Path
+        path to image
+
+    Returns
+    -------
+    num_scenes : int
+        number of scenes in image
+    """
+
+    img = BioImage(image_path)
+    num_scenes = len(img.scenes)
+    
+    return num_scenes
 


### PR DESCRIPTION
This PR adds the possibility of analyzing all images contained in a multi-scene file (e.g. as provided by nd2). When analyzing a single image, the user can switch the scene using a Spinbox. When processing a folder, all images in a multi-scene file are automatically analyzed. Masks and properties file exports get an additional suffix to specify the scene e.g. "xxx_scene1_mask.tif" 